### PR TITLE
'id' property changed by 'pk' to avoid GraphRuntimeException

### DIFF
--- a/GremlinNetSample/Program.cs
+++ b/GremlinNetSample/Program.cs
@@ -25,10 +25,10 @@ namespace GremlinNetSample
         private static Dictionary<string, string> gremlinQueries = new Dictionary<string, string>
         {
             { "Cleanup",        "g.V().drop()" },
-            { "AddVertex 1",    "g.addV('person').property('id', 'thomas').property('firstName', 'Thomas').property('age', 44)" },
-            { "AddVertex 2",    "g.addV('person').property('id', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39)" },
-            { "AddVertex 3",    "g.addV('person').property('id', 'ben').property('firstName', 'Ben').property('lastName', 'Miller')" },
-            { "AddVertex 4",    "g.addV('person').property('id', 'robin').property('firstName', 'Robin').property('lastName', 'Wakefield')" },
+            { "AddVertex 1",    "g.addV('person').property('pk', 'thomas').property('firstName', 'Thomas').property('age', 44)" },
+            { "AddVertex 2",    "g.addV('person').property('pk', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39)" },
+            { "AddVertex 3",    "g.addV('person').property('pk', 'ben').property('firstName', 'Ben').property('lastName', 'Miller')" },
+            { "AddVertex 4",    "g.addV('person').property('pk', 'robin').property('firstName', 'Robin').property('lastName', 'Wakefield')" },
             { "AddEdge 1",      "g.V('thomas').addE('knows').to(g.V('mary'))" },
             { "AddEdge 2",      "g.V('thomas').addE('knows').to(g.V('ben'))" },
             { "AddEdge 3",      "g.V('ben').addE('knows').to(g.V('robin'))" },
@@ -39,8 +39,8 @@ namespace GremlinNetSample
             { "Sort",           "g.V().hasLabel('person').order().by('firstName', decr)" },
             { "Traverse",       "g.V('thomas').out('knows').hasLabel('person')" },
             { "Traverse 2x",    "g.V('thomas').out('knows').hasLabel('person').out('knows').hasLabel('person')" },
-            { "Loop",           "g.V('thomas').repeat(out()).until(has('id', 'robin')).path()" },
-            { "DropEdge",       "g.V('thomas').outE('knows').where(inV().has('id', 'mary')).drop()" },
+            { "Loop",           "g.V('thomas').repeat(out()).until(has('pk', 'robin')).path()" },
+            { "DropEdge",       "g.V('thomas').outE('knows').where(inV().has('pk', 'mary')).drop()" },
             { "CountEdges",     "g.E().count()" },
             { "DropVertex",     "g.V('thomas').drop()" },
         };

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The following dictionary, under `Program.cs`, includes all the Gremlin queries t
 Dictionary<string, string> gremlinQueries = new Dictionary<string, string>
 {
     { "Cleanup",        "g.V().drop()" },
-    { "AddVertex 1",    "g.addV('person').property('id', 'thomas').property('firstName', 'Thomas').property('age', 44)" },
-    { "AddVertex 2",    "g.addV('person').property('id', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39)" },
-    { "AddVertex 3",    "g.addV('person').property('id', 'ben').property('firstName', 'Ben').property('lastName', 'Miller')" },
-    { "AddVertex 4",    "g.addV('person').property('id', 'robin').property('firstName', 'Robin').property('lastName', 'Wakefield')" },
+    { "AddVertex 1",    "g.addV('person').property('pk', 'thomas').property('firstName', 'Thomas').property('age', 44)" },
+    { "AddVertex 2",    "g.addV('person').property('pk', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39)" },
+    { "AddVertex 3",    "g.addV('person').property('pk', 'ben').property('firstName', 'Ben').property('lastName', 'Miller')" },
+    { "AddVertex 4",    "g.addV('person').property('pk', 'robin').property('firstName', 'Robin').property('lastName', 'Wakefield')" },
     { "AddEdge 1",      "g.V('thomas').addE('knows').to(g.V('mary'))" },
     { "AddEdge 2",      "g.V('thomas').addE('knows').to(g.V('ben'))" },
     { "AddEdge 3",      "g.V('ben').addE('knows').to(g.V('robin'))" },
@@ -49,8 +49,8 @@ Dictionary<string, string> gremlinQueries = new Dictionary<string, string>
     { "Sort",           "g.V().hasLabel('person').order().by('firstName', decr)" },
     { "Traverse",       "g.V('thomas').outE('knows').inV().hasLabel('person')" },
     { "Traverse 2x",    "g.V('thomas').outE('knows').inV().hasLabel('person').outE('knows').inV().hasLabel('person')" },
-    { "Loop",           "g.V('thomas').repeat(out()).until(has('id', 'robin')).path()" },
-    { "DropEdge",       "g.V('thomas').outE('knows').where(inV().has('id', 'mary')).drop()" },
+    { "Loop",           "g.V('thomas').repeat(out()).until(has('pk', 'robin')).path()" },
+    { "DropEdge",       "g.V('thomas').outE('knows').where(inV().has('pk', 'mary')).drop()" },
     { "CountEdges",     "g.E().count()" },
     { "DropVertex",     "g.V('thomas').drop()" },
 };


### PR DESCRIPTION
## Purpose
* This fix solve the GraphRuntimeException *Gremlin Query Execution Error: Cannot add a vertex where the partition key property has value 'null'.* because /id and /label are not supported as partition keys for a container in Gremlin API. 

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Azure-Samples/azure-cosmos-db-graph-gremlindotnet-getting-started.git
cd azure-cosmos-db-graph-gremlindotnet-getting-started
git checkout master
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->

Execute the following steps of [Quickstart: Build a .NET Framework or Core application using the Azure Cosmos DB Gremlin API account](https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-dotnet) tutorial:
1. [Create a database account](https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-dotnet#create-a-database-account)
2. [Add a graph](https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-dotnet#add-a-graph)
3. [Update your connection string](https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-dotnet#update-your-connection-string)
4. [Run the console app](https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-dotnet#run-the-console-app)

## What to Check
Verify that the following are valid
* This exception is raised:

```
Running this query: AddVertex 1: g.addV('person').property('id', 'thomas').property('firstName', 'Thomas').property('age', 44)

Unhandled Exception: System.AggregateException: One or more errors occurred. ---> Gremlin.Net.Driver.Exceptions.ResponseException: ScriptEvaluationError: 

ActivityId : 0b925cfe-1c39-4707-8639-e215ee6da5aa
ExceptionType : GraphRuntimeException
ExceptionMessage :
	Gremlin Query Execution Error: Cannot add a vertex where the partition key property has value 'null'.
Source : Microsoft.Azure.Cosmos.Gremlin.Core
	GremlinRequestId : 0b925cfe-1c39-4707-8639-e215ee6da5aa
	Context : graphcompute
	Scope : graphcomp-execquery
	GraphInterOpStatusCode : GraphRuntimeError
	HResult : 0x80131500

   at Gremlin.Net.Driver.Messages.ResponseStatusExtensions.ThrowIfStatusIndicatesError(ResponseStatus status)
   at Gremlin.Net.Driver.Connection.TryParseResponseMessage(ResponseMessage`1 receivedMsg)
   at Gremlin.Net.Driver.Connection.Parse(Byte[] received)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Gremlin.Net.Driver.ProxyConnection.<SubmitAsync>d__3`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Gremlin.Net.Driver.GremlinClient.<SubmitAsync>d__6`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Gremlin.Net.Driver.GremlinClientExtensions.<SubmitAsync>d__4`1.MoveNext()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at GremlinNetSample.Program.Main(String[] args)
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->