### PR TITLE
Really catch ResponseException

### DIFF
--- a/GremlinNetSample/Program.cs
+++ b/GremlinNetSample/Program.cs
@@ -156,11 +156,11 @@ namespace GremlinNetSample
             Console.ReadLine();
         }
 
-        private static Task<ResultSet<dynamic>> SubmitRequest(GremlinClient gremlinClient, KeyValuePair<string, string> query)
+        private static async Task<ResultSet<dynamic>> SubmitRequest(GremlinClient gremlinClient, KeyValuePair<string, string> query)
         {
             try
             {
-                return gremlinClient.SubmitAsync<dynamic>(query.Value);
+                return await gremlinClient.SubmitAsync<dynamic>(query.Value);
             }
             catch (ResponseException e)
             {


### PR DESCRIPTION
Gremlin ResponseException is not caught by catch block if the Task is not await'ed in the try block.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Duplicate ` { "AddVertex 1",    "g.addV('person').property('id', 'thomas').property('firstName', 'Thomas').property('age', 44).property('pk', 'pk')" },` and see that the ResponseException is caught.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->